### PR TITLE
bootstrap-tagsinputを最新版に

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "jquery-turbolinks"
 # css系
 gem 'sass-rails', '~> 5.0'
 gem 'bootstrap-sass'
-gem 'bootstrap-tagsinput-rails'
+gem 'bootstrap_tagsinput_rails'
 gem 'twitter-bootstrap-rails'
 
 # rails系

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,7 @@ GEM
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
-    bootstrap-tagsinput-rails (0.4.2.1)
-      railties (>= 3.1)
+    bootstrap_tagsinput_rails (0.4.0)
     builder (3.2.3)
     byebug (9.1.0)
     climate_control (0.2.0)
@@ -220,7 +219,7 @@ PLATFORMS
 DEPENDENCIES
   acts-as-taggable-on
   bootstrap-sass
-  bootstrap-tagsinput-rails
+  bootstrap_tagsinput_rails
   byebug
   coffee-rails (~> 4.2)
   coffee-script-source (= 1.8.0)


### PR DESCRIPTION
Gemfileに書いてある [bootstrap-tagsinput-rails](https://rubygems.org/gems/bootstrap-tagsinput-rails) はバージョンが更新されておらず、IE8用の古いコードが入っているためタグ編集画面のタグ入力欄の幅が3文字以上に伸びない不具合がありましたので、新しいバージョンを使ったgem [bootstrap_tagsinput_rails](https://rubygems.org/gems/bootstrap_tagsinput_rails) に差し替えました

https://github.com/luciuschoi/bootstrap-tagsinput-rails/pull/12/files#diff-bb8263974a0f3956ebd02da3f1a3af9aL46

## before
![before](https://user-images.githubusercontent.com/562795/30650075-f6a7c22e-9e5c-11e7-8e62-7e87eaa9b104.gif)

## after ✨ 
![after](https://user-images.githubusercontent.com/562795/30650078-f909c0c6-9e5c-11e7-9c45-e21e75fe8623.gif)
